### PR TITLE
Register plugin widgets with app

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ def register_plugin(app):
     import tkinter as tk
     def example_function():
         print("Plugin executed!")
-    tk.Button(app.plugin_frame, text="Example Plugin", command=example_function).pack(side=tk.LEFT, padx=5)
+    button = tk.Button(app.plugin_frame, text="Example Plugin", command=example_function)
+    app.register_plugin_widget(button)
 ```
 
 ---

--- a/plugins/backup_plugin.py
+++ b/plugins/backup_plugin.py
@@ -28,4 +28,5 @@ def register_plugin(app):
         except Exception as e:
             messagebox.showerror("Error", f"Error creating backup: {e}")
 
-    tk.Button(app.plugin_frame, text="Create Backup", command=create_backup).pack(side=tk.LEFT, padx=5)
+    backup_button = tk.Button(app.plugin_frame, text="Create Backup", command=create_backup)
+    app.register_plugin_widget(backup_button)

--- a/plugins/column_mapping_plugin.py
+++ b/plugins/column_mapping_plugin.py
@@ -94,4 +94,5 @@ def register_plugin(app):
 
         tk.Button(mapping_window, text="Apply Mapping", command=apply_mapping).grid(row=len(db_columns) + 1, columnspan=2, pady=10)
 
-    tk.Button(app.plugin_frame, text="Import File", command=import_file).pack(side=tk.LEFT, padx=5)
+    import_button = tk.Button(app.plugin_frame, text="Import File", command=import_file)
+    app.register_plugin_widget(import_button)

--- a/plugins/delete_plugin.py
+++ b/plugins/delete_plugin.py
@@ -19,4 +19,5 @@ def register_plugin(app):
         except Exception as e:
             messagebox.showerror("Error", f"Error deleting row: {e}")
 
-    tk.Button(app.plugin_frame, text="Delete Row", command=delete_row).pack(side=tk.LEFT, padx=5)
+    delete_button = tk.Button(app.plugin_frame, text="Delete Row", command=delete_row)
+    app.register_plugin_widget(delete_button)

--- a/plugins/duplicates_plugin.py
+++ b/plugins/duplicates_plugin.py
@@ -48,4 +48,5 @@ def register_plugin(app):
 
         tk.Button(window, text="Remove Duplicates", command=delete_duplicates).pack(pady=10)
 
-    tk.Button(app.plugin_frame, text="Find Duplicates", command=find_duplicates).pack(side=tk.LEFT, padx=5)
+    duplicates_button = tk.Button(app.plugin_frame, text="Find Duplicates", command=find_duplicates)
+    app.register_plugin_widget(duplicates_button)

--- a/plugins/export_plugin.py
+++ b/plugins/export_plugin.py
@@ -16,4 +16,5 @@ def register_plugin(app):
         except Exception as e:
             messagebox.showerror("Error", f"Error exporting data: {e}")
 
-    tk.Button(app.plugin_frame, text="Export CSV", command=export_to_csv).pack(side=tk.LEFT, padx=5)
+    export_button = tk.Button(app.plugin_frame, text="Export CSV", command=export_to_csv)
+    app.register_plugin_widget(export_button)

--- a/plugins/filter_plugin.py
+++ b/plugins/filter_plugin.py
@@ -21,9 +21,16 @@ def register_plugin(app):
         app.refresh_table()
 
     filter_frame = tk.Frame(app.root)
+    app.register_plugin_widget(filter_frame)
     filter_frame.pack(fill=tk.X, pady=5)
-    tk.Label(filter_frame, text="Filter:").pack(side=tk.LEFT, padx=5)
+
+    filter_label = tk.Label(filter_frame, text="Filter:")
+    app.register_plugin_widget(filter_label)
+
     app.filter_entry = tk.Entry(filter_frame)
+    app.register_plugin_widget(app.filter_entry)
     app.filter_entry.pack(side=tk.LEFT, fill=tk.X, expand=True, padx=5)
     app.filter_entry.bind("<KeyRelease>", apply_filter)
-    tk.Button(filter_frame, text="Clear Filter", command=clear_filter).pack(side=tk.LEFT, padx=5)
+
+    clear_button = tk.Button(filter_frame, text="Clear Filter", command=clear_filter)
+    app.register_plugin_widget(clear_button)

--- a/plugins/integration_plugin.py
+++ b/plugins/integration_plugin.py
@@ -66,5 +66,7 @@ def register_plugin(app):
 
         tk.Button(login_window, text="Login", command=validate_login).grid(row=2, columnspan=2, pady=10)
 
-    tk.Button(app.plugin_frame, text="Configure Remote DB", command=configure_remote_db).pack(side=tk.LEFT, padx=5)
-    tk.Button(app.plugin_frame, text="Login", command=login).pack(side=tk.LEFT, padx=5)
+    configure_button = tk.Button(app.plugin_frame, text="Configure Remote DB", command=configure_remote_db)
+    app.register_plugin_widget(configure_button)
+    login_button = tk.Button(app.plugin_frame, text="Login", command=login)
+    app.register_plugin_widget(login_button)

--- a/plugins/refresh_plugin.py
+++ b/plugins/refresh_plugin.py
@@ -1,4 +1,5 @@
 
 def register_plugin(app):
     import tkinter as tk
-    tk.Button(app.plugin_frame, text="Refresh Table", command=app.refresh_table).pack(side=tk.LEFT, padx=5)
+    refresh_button = tk.Button(app.plugin_frame, text="Refresh Table", command=app.refresh_table)
+    app.register_plugin_widget(refresh_button)

--- a/plugins/settings_plugin.py
+++ b/plugins/settings_plugin.py
@@ -161,4 +161,5 @@ def register_plugin(app):
 
         tk.Button(settings_window, text="Add Column", command=add_column).grid(row=6, column=0, pady=10)
 
-    tk.Button(app.plugin_frame, text="Settings", command=open_settings).pack(side=tk.LEFT, padx=5)
+    settings_button = tk.Button(app.plugin_frame, text="Settings", command=open_settings)
+    app.register_plugin_widget(settings_button)

--- a/plugins/validated_add_record_plugin.py
+++ b/plugins/validated_add_record_plugin.py
@@ -52,4 +52,5 @@ def register_plugin(app):
 
         tk.Button(add_window, text="Save Record", command=save_record).grid(row=len(labels), columnspan=2, pady=10)
 
-    tk.Button(app.plugin_frame, text="Add Record", command=add_record).pack(side=tk.LEFT, padx=5)
+    add_record_button = tk.Button(app.plugin_frame, text="Add Record", command=add_record)
+    app.register_plugin_widget(add_record_button)


### PR DESCRIPTION
## Summary
- Replace direct `pack` calls in plugins with explicit widget registration via `app.register_plugin_widget`
- Register non-button plugin UI elements such as filter labels and entries for consistent cleanup
- Update README example plugin to demonstrate widget registration

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68925829f0c48326bf141f3141b9394a